### PR TITLE
fix: reset context on semicolon before comment check in formatter

### DIFF
--- a/src/formatter.test.ts
+++ b/src/formatter.test.ts
@@ -417,4 +417,61 @@ describe("formatModule", () => {
       ],
     });
   });
+
+  it("does not add trailing comma after semicolon followed by comment", () => {
+    // Regression test: when a scalar const declaration's semicolon is followed
+    // by a comment, the "in-value" context was not being reset, causing
+    // spurious trailing commas in the next enum/struct.
+    const input = [
+      'const FOO: string = "bar";',
+      "",
+      "// Comment before enum",
+      "enum E {",
+      "  A = 1;",
+      "  B = 2;",
+      "}",
+      "",
+    ].join("\n");
+    const expected = [
+      'const FOO: string = "bar";',
+      "",
+      "// Comment before enum",
+      "enum E {",
+      "  A = 1;",
+      "  B = 2;",
+      "}",
+      "",
+    ].join("\n");
+    const tokens = tokenizeModule(input, "test.skir");
+    expect(tokens.errors).toMatch([]);
+    const formatted = formatModule(tokens.result, () => 0.5);
+    expect(formatted.newSourceCode).toMatch(expected);
+  });
+
+  it("does not add trailing comma in struct after const with comment", () => {
+    const input = [
+      'const REGEX: string = "foo";',
+      "",
+      "// Section",
+      "",
+      "struct Request {",
+      "  id: string;",
+      "}",
+      "",
+    ].join("\n");
+    const expected = [
+      'const REGEX: string = "foo";',
+      "",
+      "// Section",
+      "",
+      "struct Request {",
+      "  id: string;",
+      "}",
+      "",
+    ].join("\n");
+    const tokens = tokenizeModule(input, "test.skir");
+    expect(tokens.errors).toMatch([]);
+    const formatted = formatModule(tokens.result, () => 0.5);
+    expect(formatted.newSourceCode).toMatch(expected);
+  });
 });

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -169,6 +169,14 @@ function getWhitespaceAfterToken(
     context.indentStack.pop();
   }
 
+  // Reset context when we encounter a semicolon, even if the next token is a
+  // comment. Without this, the "in-value" context from a const declaration
+  // leaks past comments and into subsequent declarations, causing spurious
+  // trailing commas.
+  if (token.text === ";") {
+    context.context = null;
+  }
+
   if (isComment(token)) {
     return oneOrTwoLineBreaks(token, next);
   } else if (
@@ -200,7 +208,6 @@ function getWhitespaceAfterToken(
   } else if (token.text === ")") {
     return next.text === "{" ? " " : "";
   } else if (token.text === ";") {
-    context.context = null;
     return oneOrTwoLineBreaks(token, next);
   } else if (token.text === "}") {
     return [",", ";"].includes(next.text)


### PR DESCRIPTION
## Bug

`skir format` adds spurious `;,` after the last field of an enum/struct that follows a scalar `const` declaration when there is a comment between them.

## Reproduction

```skir
const FOO: string = "bar";

// Comment
enum E {
  A = 1;   // becomes "A = 1;,"
}
```

Triggers when:
- A scalar `const` (string, int — **not** array/object)
- At least one comment (`//`) between the const's `;` and the next `enum`/`struct`

## Root cause

In `getWhitespaceAfterToken`, the `isComment(next)` branch fires before `token.text === ";"`, so `context.context` is never reset from `"in-value"` to `null` when a semicolon is followed by a comment. The leaked context causes `shouldAddTrailingComma` to add commas inside subsequent declarations.

## Fix

Move `context.context = null` for `;` tokens **before** the if/else chain so it executes regardless of what the next token is.

All 100 existing tests pass + 2 new regression tests added.
